### PR TITLE
Import some fixes for python 3

### DIFF
--- a/slugid/slugid.py
+++ b/slugid/slugid.py
@@ -20,8 +20,8 @@ def decode(slug):
     """
     if not two and isinstance(slug, bytes):
       slug = slug.decode('ascii')
-    slug = slug + '=='
-    return uuid.UUID(bytes=base64.urlsafe_b64decode(slug)) # b64 padding
+    slug = slug + '==' # base64 padding
+    return uuid.UUID(bytes=base64.urlsafe_b64decode(slug))
 
 
 def v4():
@@ -44,5 +44,5 @@ def nice():
     restrict the range of potential uuids that may be generated.
     """
     rawBytes = bytearray(uuid.uuid4().bytes)
-    rawBytes[0] = rawBytes[0] & 0x7f;
+    rawBytes[0] = rawBytes[0] & 0x7f
     return base64.urlsafe_b64encode(rawBytes)[:-2]  # Drop '==' padding

--- a/slugid/slugid.py
+++ b/slugid/slugid.py
@@ -1,8 +1,10 @@
 # Licensed under the Mozilla Public Licence 2.0.
 # https://www.mozilla.org/en-US/MPL/2.0
 
+import sys
 import uuid
 import base64
+two = True if sys.version_info.major == 2 else False
 
 def encode(uuid_):
     """
@@ -16,7 +18,10 @@ def decode(slug):
     """
     Returns the uuid.UUID object represented by the given v4 or "nice" slug
     """
-    return uuid.UUID(bytes=base64.urlsafe_b64decode(slug + '==')) # b64 padding
+    if not two and isinstance(slug, bytes):
+      slug = slug.decode('ascii')
+    slug = slug + '=='
+    return uuid.UUID(bytes=base64.urlsafe_b64decode(slug)) # b64 padding
 
 
 def v4():
@@ -38,6 +43,6 @@ def nice():
     Potentially other "nice" properties may be added in future to further
     restrict the range of potential uuids that may be generated.
     """
-    rawBytes = uuid.uuid4().bytes
-    rawBytes = chr(ord(rawBytes[0]) & 0x7f) + rawBytes[1:]  # Ensure slug starts with [A-Za-f]
+    rawBytes = bytearray(uuid.uuid4().bytes)
+    rawBytes[0] = rawBytes[0] & 0x7f;
     return base64.urlsafe_b64encode(rawBytes)[:-2]  # Drop '==' padding

--- a/test.py
+++ b/test.py
@@ -167,7 +167,8 @@ def arraysEqual(a, b):
     if len(a) != len(b):
       return False
     for x in range(0, len(a)):
-      if cmp(a[x], b[x]) != 0:
+      # https://docs.python.org/3.0/whatsnew/3.0.html#ordering-comparisons
+      if (a[x] > b[x]) - (a[x] < b[x]) != 0:
         return False
     return True
 

--- a/test.py
+++ b/test.py
@@ -14,7 +14,7 @@ def testEncode():
     # <8 ><0 ><4 ><f ><3 ><f ><c ><8 ><d ><f ><c ><b ><4 ><b ><0 ><6 ><8 ><9 ><f ><b ><a ><e ><f ><a ><d ><5 ><e ><1 ><8 ><7 ><5 ><4 >
     # < g  >< E  >< 8  >< _  >< y  >< N  >< _  >< L  >< S  >< w  >< a  >< J  >< -  >< 6  >< 7  >< 6  >< 1  >< e  >< G  >< H  >< V  >< A  >
     uuid_ = uuid.UUID('{804f3fc8-dfcb-4b06-89fb-aefad5e18754}')
-    expectedSlug = 'gE8_yN_LSwaJ-6761eGHVA'
+    expectedSlug = b'gE8_yN_LSwaJ-6761eGHVA'
     actualSlug = slugid.encode(uuid_)
 
     assert expectedSlug == actualSlug, "UUID not correctly encoded into slug: '" + expectedSlug + "' != '" + actualSlug + "'"
@@ -160,8 +160,16 @@ def spreadTest(generator, expected):
         # sort for easy comparison
         actual[j] = ''.join(sorted(actual[j]))
 
-    assert arraysEqual(expected, actual), "In a large sample of generated slugids, the range of characters found per character position in the sample did not match expected results.\n\nExpected: " + str(expected) + "\n\nActual: " + str(actual)
+    arraysEqual(expected, actual), "In a large sample of generated slugids, the range of characters found per character position in the sample did not match expected results.\n\nExpected: " + str(expected) + "\n\nActual: " + str(actual)
 
 def arraysEqual(a, b):
     """ returns True if arrays a and b are equal"""
-    return cmp(a, b) == 0
+    assert len(a) == len(b)
+    fails = False
+    msg = []
+    for x in range(0, len(a)):
+      if 0!= cmp(a[x], b[x]):
+        fails = True
+        msg.append('Expected: ' + str(a[x]) + ' Actual: ' + str(b[x]))
+    assert not fails, '\n'.join(msg)
+

--- a/test.py
+++ b/test.py
@@ -160,16 +160,14 @@ def spreadTest(generator, expected):
         # sort for easy comparison
         actual[j] = ''.join(sorted(actual[j]))
 
-    arraysEqual(expected, actual), "In a large sample of generated slugids, the range of characters found per character position in the sample did not match expected results.\n\nExpected: " + str(expected) + "\n\nActual: " + str(actual)
+    assert arraysEqual(expected, actual), "In a large sample of generated slugids, the range of characters found per character position in the sample did not match expected results.\n\nExpected: " + str(expected) + "\n\nActual: " + str(actual)
 
 def arraysEqual(a, b):
     """ returns True if arrays a and b are equal"""
-    assert len(a) == len(b)
-    fails = False
-    msg = []
+    if len(a) != len(b):
+      return False
     for x in range(0, len(a)):
-      if 0!= cmp(a[x], b[x]):
-        fails = True
-        msg.append('Expected: ' + str(a[x]) + ' Actual: ' + str(b[x]))
-    assert not fails, '\n'.join(msg)
+      if cmp(a[x], b[x]) != 0:
+        return False
+    return True
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27
+envlist = py27,py35
 
 
 [base]

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,14 @@ commands =
     {[base]commands}
 
 
+[testenv:py35]
+deps=
+    {[base]deps}
+basepython = python3.5
+commands =
+    {[base]commands}
+
+
 [testenv:coveralls]
 deps=
     python-coveralls


### PR DESCRIPTION
Here's some work towards fixing Python 3 support.  This should work with
python 2 as well.  I tried to avoid using 'six' so we didn't add a dep.

I couldn't get the spread tests to work.  I also do not know how to make
'tox' run both the py35 and py25 environment tests...
