### PR TITLE
Py3 fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - 2.7
   - 3.5
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
   - 2.7
+  - 3.5
 
 install:
   - pip install -r requirements.txt

--- a/README.rst
+++ b/README.rst
@@ -5,8 +5,9 @@ slugid.py - Compressed UUIDs for python
 
 |Build Status| |Coverage Status| |License| |pypi Version| |Downloads|
 
-A python module for generating v4 UUIDs and encoding them into 22 character
-URL-safe base64 slug representation (see `RFC 4648 sec. 5`_).
+A python 2.7 and python 3.5 compatible module for generating v4 UUIDs and
+encoding them into 22 character URL-safe base64 slug representation (see `RFC
+4648 sec. 5`_).
 
 Slugs are url-safe base64 encoded v4 uuids, stripped of base64 ``=`` padding.
 

--- a/setup.py
+++ b/setup.py
@@ -34,5 +34,6 @@ setup(
         'Intended Audience :: Developers',
         'Natural Language :: English',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.5',
     ),
 )

--- a/slugid/__init__.py
+++ b/slugid/__init__.py
@@ -34,10 +34,15 @@ Usage:
    >>> slugid.v4()
    -9OpXaCORAaFh4sJRk7PUA
 """
+from .slugid import decode, encode, nice, v4
 
 __title__ = 'slugid'
 __version__ = '1.0.6'
 __author__ = 'Peter Moore'
 __license__ = 'MPL 2.0'
-
-from .slugid import decode, encode, nice, v4
+__all__ = [
+     'decode',
+     'encode',
+     'nice',
+     'v4',
+]

--- a/slugid/slugid.py
+++ b/slugid/slugid.py
@@ -20,8 +20,8 @@ def decode(slug):
     """
     if not two and isinstance(slug, bytes):
       slug = slug.decode('ascii')
-    slug = slug + '=='
-    return uuid.UUID(bytes=base64.urlsafe_b64decode(slug)) # b64 padding
+    slug = slug + '==' # base64 padding
+    return uuid.UUID(bytes=base64.urlsafe_b64decode(slug))
 
 
 def v4():
@@ -44,5 +44,5 @@ def nice():
     restrict the range of potential uuids that may be generated.
     """
     rawBytes = bytearray(uuid.uuid4().bytes)
-    rawBytes[0] = rawBytes[0] & 0x7f;
+    rawBytes[0] = rawBytes[0] & 0x7f
     return base64.urlsafe_b64encode(rawBytes)[:-2]  # Drop '==' padding

--- a/slugid/slugid.py
+++ b/slugid/slugid.py
@@ -4,7 +4,6 @@
 import sys
 import uuid
 import base64
-two = True if sys.version_info.major == 2 else False
 
 def encode(uuid_):
     """
@@ -18,8 +17,8 @@ def decode(slug):
     """
     Returns the uuid.UUID object represented by the given v4 or "nice" slug
     """
-    if not two and isinstance(slug, bytes):
-      slug = slug.decode('ascii')
+    if sys.version_info.major != 2 and isinstance(slug, bytes):
+        slug = slug.decode('ascii')
     slug = slug + '==' # base64 padding
     return uuid.UUID(bytes=base64.urlsafe_b64decode(slug))
 
@@ -44,5 +43,5 @@ def nice():
     restrict the range of potential uuids that may be generated.
     """
     rawBytes = bytearray(uuid.uuid4().bytes)
-    rawBytes[0] = rawBytes[0] & 0x7f
+    rawBytes[0] = rawBytes[0] & 0x7f  # Ensure slug starts with [A-Za-f]
     return base64.urlsafe_b64encode(rawBytes)[:-2]  # Drop '==' padding

--- a/slugid/slugid.py
+++ b/slugid/slugid.py
@@ -5,12 +5,13 @@ import sys
 import uuid
 import base64
 
+
 def encode(uuid_):
     """
-	Returns the given uuid.UUID object as a 22 character slug. This can be a
-	regular v4 slug or a "nice" slug.
+    Returns the given uuid.UUID object as a 22 character slug. This can be a
+    regular v4 slug or a "nice" slug.
     """
-    return base64.urlsafe_b64encode(uuid_.bytes)[:-2] # Drop '==' padding
+    return base64.urlsafe_b64encode(uuid_.bytes)[:-2]  # Drop '==' padding
 
 
 def decode(slug):
@@ -19,7 +20,7 @@ def decode(slug):
     """
     if sys.version_info.major != 2 and isinstance(slug, bytes):
         slug = slug.decode('ascii')
-    slug = slug + '==' # base64 padding
+    slug = slug + '=='  # base64 padding
     return uuid.UUID(bytes=base64.urlsafe_b64decode(slug))
 
 
@@ -27,7 +28,7 @@ def v4():
     """
     Returns a randomly generated uuid v4 compliant slug
     """
-    return base64.urlsafe_b64encode(uuid.uuid4().bytes)[:-2] # Drop '==' padding
+    return base64.urlsafe_b64encode(uuid.uuid4().bytes)[:-2]  # Drop '==' padding
 
 
 def nice():

--- a/slugid/slugid.py
+++ b/slugid/slugid.py
@@ -1,8 +1,10 @@
 # Licensed under the Mozilla Public Licence 2.0.
 # https://www.mozilla.org/en-US/MPL/2.0
 
+import sys
 import uuid
 import base64
+two = True if sys.version_info.major == 2 else False
 
 def encode(uuid_):
     """
@@ -16,7 +18,10 @@ def decode(slug):
     """
     Returns the uuid.UUID object represented by the given v4 or "nice" slug
     """
-    return uuid.UUID(bytes=base64.urlsafe_b64decode(slug + '==')) # b64 padding
+    if not two and isinstance(slug, bytes):
+      slug = slug.decode('ascii')
+    slug = slug + '=='
+    return uuid.UUID(bytes=base64.urlsafe_b64decode(slug)) # b64 padding
 
 
 def v4():
@@ -38,6 +43,6 @@ def nice():
     Potentially other "nice" properties may be added in future to further
     restrict the range of potential uuids that may be generated.
     """
-    rawBytes = uuid.uuid4().bytes
-    rawBytes = chr(ord(rawBytes[0]) & 0x7f) + rawBytes[1:]  # Ensure slug starts with [A-Za-f]
+    rawBytes = bytearray(uuid.uuid4().bytes)
+    rawBytes[0] = rawBytes[0] & 0x7f;
     return base64.urlsafe_b64encode(rawBytes)[:-2]  # Drop '==' padding

--- a/test.py
+++ b/test.py
@@ -17,7 +17,8 @@ def testEncode():
     expectedSlug = b'gE8_yN_LSwaJ-6761eGHVA'
     actualSlug = slugid.encode(uuid_)
 
-    assert expectedSlug == actualSlug, "UUID not correctly encoded into slug: '" + expectedSlug + "' != '" + actualSlug + "'"
+    assert expectedSlug == actualSlug, "UUID not correctly encoded into slug: '" + \
+        expectedSlug + "' != '" + actualSlug + "'"
 
 
 def testDecode():
@@ -31,7 +32,8 @@ def testDecode():
     expectedUuid = uuid.UUID('{fbefbefb-efbe-43ef-bfff-fffffffffffd}')
     actualUuid = slugid.decode(slug)
 
-    assert expectedUuid == actualUuid, "Slug not correctly decoded into uuid: '" + str(expectedUuid) + "' != '" + str(actualUuid) + "'"
+    assert expectedUuid == actualUuid, "Slug not correctly decoded into uuid: '" + \
+        str(expectedUuid) + "' != '" + str(actualUuid) + "'"
 
 
 def testUuidEncodeDecode():
@@ -94,7 +96,9 @@ def testSpreadNice():
     => $E in {C, G, K, O, S, W, a, e, i, m, q, u, y, 2, 6, -} (0bxxxx10)
     => $F in {A, Q, g, w} (0bxx0000)"""
 
-    charsAll = bytearray(sorted(b'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_'))
+    charsAll = bytearray(
+        sorted(b'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_')
+    )
     # 0 - 31: 0b0xxxxx
     charsC = bytearray(sorted(b'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef'))
     # 16, 17, 18, 19: 0b0100xx
@@ -103,7 +107,11 @@ def testSpreadNice():
     charsE = bytearray(sorted(b'CGKOSWaeimquy26-'))
     # 0, 16, 32, 48: 0bxx0000
     charsF = bytearray(sorted(b'AQgw'))
-    expected = [charsC, charsAll, charsAll, charsAll, charsAll, charsAll, charsAll, charsAll, charsD, charsAll, charsE, charsAll, charsAll, charsAll, charsAll, charsAll, charsAll, charsAll, charsAll, charsAll, charsAll, charsF]
+    expected = [
+        charsC, charsAll, charsAll, charsAll, charsAll, charsAll, charsAll, charsAll,
+        charsD, charsAll, charsE, charsAll, charsAll, charsAll, charsAll, charsAll,
+        charsAll, charsAll, charsAll, charsAll, charsAll, charsF
+    ]
     spreadTest(slugid.nice, expected)
 
 
@@ -112,14 +120,20 @@ def testSpreadV4():
     slugid.nice(). The only difference is that a v4() slug can start with any of
     the base64 characters since the first six bits of the uuid are random."""
 
-    charsAll = bytearray(sorted(b'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_'))
+    charsAll = bytearray(
+        sorted(b'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_')
+    )
     # 16, 17, 18, 19: 0b0100xx
     charsD = bytearray(sorted(b'QRST'))
     # 2, 6, 10, 14, 18, 22, 26, 30, 34, 38, 42, 46, 50, 54, 58, 62: 0bxxxx10
     charsE = bytearray(sorted(b'CGKOSWaeimquy26-'))
     # 0, 16, 32, 48: 0bxx0000
     charsF = bytearray(sorted(b'AQgw'))
-    expected = [charsAll, charsAll, charsAll, charsAll, charsAll, charsAll, charsAll, charsAll, charsD, charsAll, charsE, charsAll, charsAll, charsAll, charsAll, charsAll, charsAll, charsAll, charsAll, charsAll, charsAll, charsF]
+    expected = [
+        charsAll, charsAll, charsAll, charsAll, charsAll, charsAll, charsAll, charsAll,
+        charsD, charsAll, charsE, charsAll, charsAll, charsAll, charsAll, charsAll,
+        charsAll, charsAll, charsAll, charsAll, charsAll, charsF
+    ]
     spreadTest(slugid.v4, expected)
 
 
@@ -161,7 +175,10 @@ def spreadTest(generator, expected):
         # sort for easy comparison
         actual[j] = bytearray(sorted(blocks))
 
-    assert arraysEqual(expected, actual), "In a large sample of generated slugids, the range of characters found per character position in the sample did not match expected results.\n\nExpected: " + str(expected) + "\n\nActual: " + str(actual)
+    assert arraysEqual(expected, actual), \
+        "In a large sample of generated slugids, the range of characters found " \
+        "per character position in the sample did not match expected results.\n\n" \
+        "Expected: " + str(expected) + "\n\nActual: " + str(actual)
 
 
 def arraysEqual(a, b):

--- a/test.py
+++ b/test.py
@@ -167,7 +167,8 @@ def arraysEqual(a, b):
     if len(a) != len(b):
       return False
     for x in range(0, len(a)):
-      if cmp(a[x], b[x]) != 0:
+      # https://docs.python.org/3.0/whatsnew/3.0.html#ordering-comparisons
+      if (a[x] > b[x]) - (a[x] < b[x]) != 0:
         return False
     return True
 

--- a/test.py
+++ b/test.py
@@ -14,7 +14,7 @@ def testEncode():
     # <8 ><0 ><4 ><f ><3 ><f ><c ><8 ><d ><f ><c ><b ><4 ><b ><0 ><6 ><8 ><9 ><f ><b ><a ><e ><f ><a ><d ><5 ><e ><1 ><8 ><7 ><5 ><4 >
     # < g  >< E  >< 8  >< _  >< y  >< N  >< _  >< L  >< S  >< w  >< a  >< J  >< -  >< 6  >< 7  >< 6  >< 1  >< e  >< G  >< H  >< V  >< A  >
     uuid_ = uuid.UUID('{804f3fc8-dfcb-4b06-89fb-aefad5e18754}')
-    expectedSlug = 'gE8_yN_LSwaJ-6761eGHVA'
+    expectedSlug = b'gE8_yN_LSwaJ-6761eGHVA'
     actualSlug = slugid.encode(uuid_)
 
     assert expectedSlug == actualSlug, "UUID not correctly encoded into slug: '" + expectedSlug + "' != '" + actualSlug + "'"
@@ -160,8 +160,16 @@ def spreadTest(generator, expected):
         # sort for easy comparison
         actual[j] = ''.join(sorted(actual[j]))
 
-    assert arraysEqual(expected, actual), "In a large sample of generated slugids, the range of characters found per character position in the sample did not match expected results.\n\nExpected: " + str(expected) + "\n\nActual: " + str(actual)
+    arraysEqual(expected, actual), "In a large sample of generated slugids, the range of characters found per character position in the sample did not match expected results.\n\nExpected: " + str(expected) + "\n\nActual: " + str(actual)
 
 def arraysEqual(a, b):
     """ returns True if arrays a and b are equal"""
-    return cmp(a, b) == 0
+    assert len(a) == len(b)
+    fails = False
+    msg = []
+    for x in range(0, len(a)):
+      if 0!= cmp(a[x], b[x]):
+        fails = True
+        msg.append('Expected: ' + str(a[x]) + ' Actual: ' + str(b[x]))
+    assert not fails, '\n'.join(msg)
+

--- a/test.py
+++ b/test.py
@@ -160,16 +160,14 @@ def spreadTest(generator, expected):
         # sort for easy comparison
         actual[j] = ''.join(sorted(actual[j]))
 
-    arraysEqual(expected, actual), "In a large sample of generated slugids, the range of characters found per character position in the sample did not match expected results.\n\nExpected: " + str(expected) + "\n\nActual: " + str(actual)
+    assert arraysEqual(expected, actual), "In a large sample of generated slugids, the range of characters found per character position in the sample did not match expected results.\n\nExpected: " + str(expected) + "\n\nActual: " + str(actual)
 
 def arraysEqual(a, b):
     """ returns True if arrays a and b are equal"""
-    assert len(a) == len(b)
-    fails = False
-    msg = []
+    if len(a) != len(b):
+      return False
     for x in range(0, len(a)):
-      if 0!= cmp(a[x], b[x]):
-        fails = True
-        msg.append('Expected: ' + str(a[x]) + ' Actual: ' + str(b[x]))
-    assert not fails, '\n'.join(msg)
+      if cmp(a[x], b[x]) != 0:
+        return False
+    return True
 

--- a/test.py
+++ b/test.py
@@ -162,13 +162,13 @@ def spreadTest(generator, expected):
 
     assert arraysEqual(expected, actual), "In a large sample of generated slugids, the range of characters found per character position in the sample did not match expected results.\n\nExpected: " + str(expected) + "\n\nActual: " + str(actual)
 
+
 def arraysEqual(a, b):
     """ returns True if arrays a and b are equal"""
     if len(a) != len(b):
-      return False
-    for x in range(0, len(a)):
-      # https://docs.python.org/3.0/whatsnew/3.0.html#ordering-comparisons
-      if (a[x] > b[x]) - (a[x] < b[x]) != 0:
         return False
+    for x in range(0, len(a)):
+        # https://docs.python.org/3.0/whatsnew/3.0.html#ordering-comparisons
+        if (a[x] > b[x]) - (a[x] < b[x]) != 0:
+            return False
     return True
-

--- a/test.py
+++ b/test.py
@@ -94,15 +94,15 @@ def testSpreadNice():
     => $E in {C, G, K, O, S, W, a, e, i, m, q, u, y, 2, 6, -} (0bxxxx10)
     => $F in {A, Q, g, w} (0bxx0000)"""
 
-    charsAll = ''.join(sorted('ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_'))
+    charsAll = bytearray(sorted(b'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_'))
     # 0 - 31: 0b0xxxxx
-    charsC = ''.join(sorted('ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef'))
+    charsC = bytearray(sorted(b'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef'))
     # 16, 17, 18, 19: 0b0100xx
-    charsD = ''.join(sorted('QRST'))
+    charsD = bytearray(sorted(b'QRST'))
     # 2, 6, 10, 14, 18, 22, 26, 30, 34, 38, 42, 46, 50, 54, 58, 62: 0bxxxx10
-    charsE = ''.join(sorted('CGKOSWaeimquy26-'))
+    charsE = bytearray(sorted(b'CGKOSWaeimquy26-'))
     # 0, 16, 32, 48: 0bxx0000
-    charsF = ''.join(sorted('AQgw'))
+    charsF = bytearray(sorted(b'AQgw'))
     expected = [charsC, charsAll, charsAll, charsAll, charsAll, charsAll, charsAll, charsAll, charsD, charsAll, charsE, charsAll, charsAll, charsAll, charsAll, charsAll, charsAll, charsAll, charsAll, charsAll, charsAll, charsF]
     spreadTest(slugid.nice, expected)
 
@@ -112,13 +112,13 @@ def testSpreadV4():
     slugid.nice(). The only difference is that a v4() slug can start with any of
     the base64 characters since the first six bits of the uuid are random."""
 
-    charsAll = ''.join(sorted('ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_'))
+    charsAll = bytearray(sorted(b'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_'))
     # 16, 17, 18, 19: 0b0100xx
-    charsD = ''.join(sorted('QRST'))
+    charsD = bytearray(sorted(b'QRST'))
     # 2, 6, 10, 14, 18, 22, 26, 30, 34, 38, 42, 46, 50, 54, 58, 62: 0bxxxx10
-    charsE = ''.join(sorted('CGKOSWaeimquy26-'))
+    charsE = bytearray(sorted(b'CGKOSWaeimquy26-'))
     # 0, 16, 32, 48: 0bxx0000
-    charsF = ''.join(sorted('AQgw'))
+    charsF = bytearray(sorted(b'AQgw'))
     expected = [charsAll, charsAll, charsAll, charsAll, charsAll, charsAll, charsAll, charsAll, charsD, charsAll, charsE, charsAll, charsAll, charsAll, charsAll, charsAll, charsAll, charsAll, charsAll, charsAll, charsAll, charsF]
     spreadTest(slugid.v4, expected)
 
@@ -153,12 +153,13 @@ def spreadTest(generator, expected):
     # Compose results into an array `actual`, for comparison with `expected`
     actual = []
     for j in range(0, len(k)):
-        actual.append('')
+        actual.append(b'')
+        blocks = bytearray()
         for a in k[j].keys():
             if k[j][a] > 0:
-                actual[j] += a
+                blocks.append(a)
         # sort for easy comparison
-        actual[j] = ''.join(sorted(actual[j]))
+        actual[j] = bytearray(sorted(blocks))
 
     assert arraysEqual(expected, actual), "In a large sample of generated slugids, the range of characters found per character position in the sample did not match expected results.\n\nExpected: " + str(expected) + "\n\nActual: " + str(actual)
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27
+envlist = py27,py35
 
 
 [base]

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,14 @@ commands =
     {[base]commands}
 
 
+[testenv:py35]
+deps=
+    {[base]deps}
+basepython = python3.5
+commands =
+    {[base]commands}
+
+
 [testenv:coveralls]
 deps=
     python-coveralls


### PR DESCRIPTION
This branch adds onto jhford's initial patches.
- addresses some of pete's review comments
- fixes flake8, except for line lengths in test.py.  I wasn't sure if we wanted to mess with text wrap on those.
- gets the tests green in py35 and py27.  lots of bytearrays.

Questions for Pete:
- Do we care about line lengths in test.py?  I would like to wrap them to under 100chars if that's ok with you, but the comments are pretty lengthy.
- Is avoiding adding six as a dependency actually a goal here?  I prefer using six whenever I have to straddle py2 and py3, but it's not a requirement.  I was wondering if that was your requirement, or jhford's preference.
