### PR TITLE
Fix coverage reporting

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,5 @@
+; .coveragerc to control coverage.py
+[run]
+; This isn't about git branches, this is about execution branches, see
+; http://coverage.readthedocs.org/en/coverage-4.0.3/branch.html#branch
+branch = True

--- a/tox.ini
+++ b/tox.ini
@@ -28,6 +28,8 @@ commands =
 
 
 [testenv:coveralls]
+; as per https://github.com/coagulant/coveralls-python#usage-tox--v20
+passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
 deps=
     python-coveralls
 commands=


### PR DESCRIPTION
Coverage reporting was broken (causing the grey badge in the README.md) but this [fixes it](https://travis-ci.org/taskcluster/slugid.py/builds/108741952#L188-L189). :dancers: 

The previous issue which broke coverage reporting (422 status code from coveralls) originally reported in lemurheavy/coveralls-public#612 has also recovered now. Thanks @nickmerwin for your help, and highlighting the new issue that this PR fixes.
