### PR TITLE
Add Homepage and Source project URLs for PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,4 +36,9 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.5',
     ),
+    project_urls={
+        'Homepage': 'http://taskcluster.github.io/slugid.py',
+        'Source': 'https://github.com/taskcluster/slugid.py',
+    },
+
 )


### PR DESCRIPTION
Add links to the homepage and source on PyPI, via [project_urls](https://packaging.python.org/guides/distributing-packages-using-setuptools/#project-urls).

This will also allow tools like Dependabot to programatically find this repo when creating update PRs.